### PR TITLE
Reordered position of inputProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,6 @@ class TagInput extends Component {
               <View style={[styles.textInputContainer, { width: this.state.inputWidth }]}>
                 <TextInput
                   ref="tagInput"
-                  {...inputProps}
                   blurOnSubmit={false}
                   onKeyPress={this.onKeyPress}
                   value={text}
@@ -293,6 +292,7 @@ class TagInput extends Component {
                 }]}
                   onChange={this.onChange}
                   onSubmitEditing={this.parseTags}
+                  {...inputProps}
                 />
               </View>
             </View>


### PR DESCRIPTION
Transferring to the bottom allows customizing/overwriting any props for Tag TextInput. An example use case would be to change styling for the text input.