### PR TITLE
wrapperHeight refactor

### DIFF
--- a/Example/src/TagInputExample.js
+++ b/Example/src/TagInputExample.js
@@ -36,7 +36,7 @@ export default class TagInputExample extends Component {
             tagColor="blue"
             tagTextColor="white"
             inputProps={inputProps}
-            numberOfLines={2}
+            maxHeight={75}
           />
         </View>
       </View>

--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ import TagInput from 'react-native-tag-input';
 | inputColor | Color of text input |
 | inputProps | Any misc. TextInput props (autofocus, placeholder, returnKeyType, etc.) |
 | maxHeight | Max height of the tag input on screen (will scroll if max height reached) |
-| parseOnBlur | whether to treat a blur event as a separator entry (iOS-only) |
+| onHeightChange | Callback that gets passed the new component height when it changes |
+| parseOnBlur | Whether to treat a blur event as a separator entry (iOS-only) |

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ import TagInput from 'react-native-tag-input';
 | tagTextStyle | Styling override for tag's text component |
 | inputColor | Color of text input |
 | inputProps | Any misc. TextInput props (autofocus, placeholder, returnKeyType, etc.) |
-| numberOfLines | Maximum number of lines of the tag input |
+| maxHeight | Max height of the tag input on screen (will scroll if max height reached) |
 | parseOnBlur | whether to treat a blur event as a separator entry (iOS-only) |

--- a/index.js
+++ b/index.js
@@ -321,19 +321,20 @@ class TagInput<T> extends React.PureComponent<OptionalProps, Props<T>, State> {
 
 }
 
+type TagProps = {
+  index: number,
+  label: string,
+  isLastTag: bool,
+  onLayoutLastTag: (endPosOfTag: number) => void,
+  removeIndex: (index: number) => void,
+  tagColor: string,
+  tagTextColor: string,
+  tagContainerStyle?: StyleObj,
+  tagTextStyle?: StyleObj,
+};
 class Tag extends React.PureComponent {
 
-  props: {
-    index: number,
-    label: string,
-    isLastTag: bool,
-    onLayoutLastTag: (endPosOfTag: number) => void,
-    removeIndex: (index: number) => void,
-    tagColor: string,
-    tagTextColor: string,
-    tagContainerStyle?: StyleObj,
-    tagTextStyle?: StyleObj,
-  };
+  props: TagProps;
   static propTypes = {
     index: PropTypes.number.isRequired,
     label: PropTypes.string.isRequired,
@@ -345,16 +346,24 @@ class Tag extends React.PureComponent {
     tagContainerStyle: ViewPropTypes.style,
     tagTextStyle: Text.propTypes.style,
   };
+  curPos: ?number = null;
+
+  componentWillReceiveProps(nextProps: TagProps) {
+    if (
+      !this.props.isLastTag &&
+      nextProps.isLastTag &&
+      this.curPos !== null &&
+      this.curPos !== undefined
+    ) {
+      this.props.onLayoutLastTag(this.curPos);
+    }
+  }
 
   render() {
-    let onLayout = undefined;
-    if (this.props.isLastTag) {
-      onLayout = this.onLayoutLastTag;
-    }
     return (
       <TouchableOpacity
         onPress={this.onPress}
-        onLayout={onLayout}
+        onLayout={this.onLayoutLastTag}
         style={[
           styles.tag,
           { backgroundColor: this.props.tagColor },
@@ -381,7 +390,10 @@ class Tag extends React.PureComponent {
     event: { nativeEvent: { layout: { x: number, width: number } } },
   ) => {
     const layout = event.nativeEvent.layout;
-    this.props.onLayoutLastTag(layout.width + layout.x);
+    this.curPos = layout.width + layout.x;
+    if (this.props.isLastTag) {
+      this.props.onLayoutLastTag(this.curPos);
+    }
   }
 
 }

--- a/index.js
+++ b/index.js
@@ -87,7 +87,11 @@ type OptionalProps = {
    */
   maxHeight: number,
   /**
-   * whether to treat a blur event as a separator entry (iOS-only)
+   * Callback that gets passed the new component height when it changes
+   */
+  onHeightChange?: (height: number) => void,
+  /**
+   * Whether to treat a blur event as a separator entry (iOS-only)
    */
   parseOnBlur: bool,
 };
@@ -116,6 +120,7 @@ class TagInput<T> extends React.PureComponent<OptionalProps, Props<T>, State> {
     inputColor: PropTypes.string,
     inputProps: PropTypes.shape(TextInput.propTypes),
     maxHeight: PropTypes.number,
+    onHeightChange: PropTypes.func,
     parseOnBlur: PropTypes.bool,
   };
   props: Props<T>;
@@ -149,6 +154,15 @@ class TagInput<T> extends React.PureComponent<OptionalProps, Props<T>, State> {
     );
     if (wrapperHeight !== this.state.wrapperHeight) {
       this.setState({ wrapperHeight });
+    }
+  }
+
+  componentWillUpdate(nextProps: Props<T>, nextState: State) {
+    if (
+      this.props.onHeightChange &&
+      nextState.wrapperHeight !== this.state.wrapperHeight
+    ) {
+      this.props.onHeightChange(nextState.wrapperHeight);
     }
   }
 


### PR DESCRIPTION
Currently, `wrapperHeight` is determined in the following way:
- `this.state.lines` starts out at 1
- `wrapperHeight = (this.state.lines - 1) * 40 + 36`
- `this.state.lines` never goes above `this.props.numberOfLines`
- `this.state.lines` gets incremented whenever `onLayoutLastTag` is called with `spaceLeft < 100`

My proposal:
- `this.state.wrapperHeight = Math.min(this.props.maxHeight, this.contentHeight)`
- `this.state.wrapperHeight` gets updated whenever either of those inputs changes
- Also, I've added a callback `this.props.onHeightChange` that gets called when `this.state.wrapperHeight` changes

Relatedly, this PR changes the logic for when `scrollToBottom` gets triggered. In this PR it gets called whenever `this.contentHeight` increases. In the current version, it gets triggered whenever `onLayoutLastTag` gets called and the max `this.props.numberOfLines` has already been reached. I found the current behavior buggy, and it doesn't always get triggered when you would expect it to.