### PR TITLE
Make TagInput a "controlled" component by "lifting" text state

### DIFF
--- a/Example/src/TagInputExample.js
+++ b/Example/src/TagInputExample.js
@@ -19,11 +19,21 @@ export default class TagInputExample extends Component {
 
   onChangeTags = (tags) => {
     this.setState({ tags });
-  };
+  }
 
   onChangeText = (text) => {
     this.setState({ text });
-  };
+
+    const lastTyped = text.charAt(text.length - 1);
+    const parseWhen = [',', ' ', ';', '\n'];
+
+    if (parseWhen.indexOf(lastTyped) > -1) {
+      this.setState({
+        tags: [...this.state.tags, this.state.text],
+        text: "",
+      });
+    }
+  }
 
   labelExtractor = (tag) => tag;
 

--- a/Example/src/TagInputExample.js
+++ b/Example/src/TagInputExample.js
@@ -5,26 +5,29 @@ import {
 } from 'react-native';
 import TagInput from 'react-native-tag-input';
 
+const inputProps = {
+  keyboardType: 'default',
+  placeholder: 'email',
+  autoFocus: true,
+};
+
 export default class TagInputExample extends Component {
   state = {
     tags: [],
+    text: "",
   };
 
   onChangeTags = (tags) => {
-    this.setState({
-      tags,
-    });
+    this.setState({ tags });
+  };
+
+  onChangeText = (text) => {
+    this.setState({ text });
   };
 
   labelExtractor = (tag) => tag;
 
   render() {
-    const inputProps = {
-      keyboardType: 'default',
-      placeholder: 'email',
-      autoFocus: true,
-    };
-
     return (
       <View style={{ flex: 1, margin: 10, marginTop: 30 }}>
         <View style={{ flexDirection: 'row', alignItems: 'center'}}>
@@ -33,6 +36,8 @@ export default class TagInputExample extends Component {
             value={this.state.tags}
             onChange={this.onChangeTags}
             labelExtractor={this.labelExtractor}
+            text={this.state.text}
+            onChangeText={this.onChangeText}
             tagColor="blue"
             tagTextColor="white"
             inputProps={inputProps}

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -1811,9 +1811,9 @@ find-up@^1.0.0, find-up@^1.1.2:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-flow-bin@^0.51.1:
-  version "0.51.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.51.1.tgz#7929c6f0a94e765429fcb2ee6e468278faa9c732"
+flow-bin@^0.53.0:
+  version "0.53.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.53.1.tgz#9b22b63a23c99763ae533ebbab07f88c88c97d84"
 
 for-each@~0.3.2:
   version "0.3.2"

--- a/README.md
+++ b/README.md
@@ -11,19 +11,21 @@ import TagInput from 'react-native-tag-input';
 
 <TagInput
   value={this.state.emails}
-  onChange={(emails) => this.onEmailChange(emails)}
+  onChange={(emails) => this.setState({ emails })}
   labelExtractor={(email) => email}
+  text={this.state.text}
+  onChangeText={(text) => this.setState({ text })}
 />
 ```
 
 
 | Available Properties | Description |
 -----------------------|-----------------
-| onChange | (Required) A handler to be called when array of tags change. When new tags are added, they are appended as strings. If you use a non-string item type, make sure to either translate the strings to your item type before passing this value on to the "value" prop, or otherwise make sure your labelExtractor can handle both your item type and strings. |
-| value | (Required) An array of tags, which can be any type, as long as labelExtractor below can extract a string from it. |
+| value | (Required) An array of tags, which can be any type, as long as labelExtractor below can extract a string from it |
+| onChange | (Required) A handler to be called when array of tags change. The parent should update the value prop when this is called if they want to enable removal of tags |
 | labelExtractor | (Required) Function to extract string value for label from item |
-| separators | An array of characters to use as tag separators |
-| regex | A RegExp to test tags after enter, space, or a comma is pressed |
+| text | (Required) The text currently being displayed in the TextInput following the list of tags |
+| onChangeText | (Required) This callback gets called when the user in the TextInput. The parent should update the text prop when this is called if they want to enable input. This is also where any parsing to detect new tags should occur |
 | tagColor | Background color of tags |
 | tagTextColor | Text color of tags |
 | tagContainerStyle | Styling override for container surrounding tag text |
@@ -32,4 +34,3 @@ import TagInput from 'react-native-tag-input';
 | inputProps | Any misc. TextInput props (autoFocus, placeholder, returnKeyType, etc.) |
 | maxHeight | Max height of the tag input on screen (will scroll if max height reached) |
 | onHeightChange | Callback that gets passed the new component height when it changes |
-| parseOnBlur | Whether to treat a blur event as a separator entry (iOS-only) |


### PR DESCRIPTION
1. Lifts `text` state up to parent to enable more complex use cases
2. Add a prop `onChangeText` that gets called whenever the text changes, and is used to update `text` prop, as well as to parse any new tags and update `value` accordingly
3. `parseTags` and associated props (`seperators`, `regex`, and `parseOnBlur`)  are removed in favor of having the client handle this logic themselves

More details in #39.