### PR TITLE
Support scrollHorizontal and other scrollViewProps

### DIFF
--- a/Example/src/TagInputExample.js
+++ b/Example/src/TagInputExample.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import {
   Text,
   View,
+  Platform,
 } from 'react-native';
 import TagInput from 'react-native-tag-input';
 
@@ -9,12 +10,33 @@ const inputProps = {
   keyboardType: 'default',
   placeholder: 'email',
   autoFocus: true,
+  style: {
+    fontSize: 14,
+    marginVertical: Platform.OS == 'ios' ? 10 : -2,
+  },
+};
+
+const horizontalInputProps = {
+  keyboardType: 'default',
+  returnKeyType: 'search',
+  placeholder: 'Search',
+  style: {
+    fontSize: 14,
+    marginVertical: Platform.OS == 'ios' ? 10 : -2,
+  },
+};
+
+const horizontalScrollViewProps = {
+  horizontal: true,
+  showsHorizontalScrollIndicator: false,
 };
 
 export default class TagInputExample extends Component {
   state = {
     tags: [],
     text: "",
+    horizontalTags: [],
+    horizontalText: "",
   };
 
   onChangeTags = (tags) => {
@@ -37,10 +59,33 @@ export default class TagInputExample extends Component {
 
   labelExtractor = (tag) => tag;
 
+  onChangeHorizontalTags = (horizontalTags) => {
+    this.setState({
+      horizontalTags,
+    });
+  };
+
+  onChangeHorizontalText = (horizontalText) => {
+    this.setState({ horizontalText });
+
+    const lastTyped = horizontalText.charAt(horizontalText.length - 1);
+    const parseWhen = [',', ' ', ';', '\n'];
+
+    if (parseWhen.indexOf(lastTyped) > -1) {
+      this.setState({
+        horizontalTags: [...this.state.horizontalTags, this.state.horizontalText],
+        horizontalText: "",
+      });
+      this._horizontalTagInput.scrollToRight();
+    }
+  }
+
   render() {
     return (
       <View style={{ flex: 1, margin: 10, marginTop: 30 }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center'}}>
+
+        <Text style={{marginVertical: 10}}>Vertical Scroll</Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: 'lightgray'}}>
           <Text>To: </Text>
           <TagInput
             value={this.state.tags}
@@ -54,6 +99,24 @@ export default class TagInputExample extends Component {
             maxHeight={75}
           />
         </View>
+
+        <Text style={{marginVertical: 10}}>Horizontal Scroll</Text>
+        <View style={{marginBottom: 10, flexDirection: 'row', alignItems: 'center', backgroundColor: 'lightgray'}}>
+          <Text>To: </Text>
+          <TagInput
+            ref={(horizontalTagInput) => {this._horizontalTagInput = horizontalTagInput}}
+            value={this.state.horizontalTags}
+            onChange={this.onChangeHorizontalTags}
+            labelExtractor={this.labelExtractor}
+            text={this.state.horizontalText}
+            onChangeText={this.onChangeHorizontalText}
+            tagColor="blue"
+            tagTextColor="white"
+            inputProps={horizontalInputProps}
+            scrollViewProps={horizontalScrollViewProps}
+          />
+        </View>
+
       </View>
     );
   }

--- a/Example/src/TagInputExample.js
+++ b/Example/src/TagInputExample.js
@@ -76,7 +76,7 @@ export default class TagInputExample extends Component {
         horizontalTags: [...this.state.horizontalTags, this.state.horizontalText],
         horizontalText: "",
       });
-      this._horizontalTagInput.scrollToRight();
+      this._horizontalTagInput.scrollToEnd();
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ import TagInput from 'react-native-tag-input';
 | inputProps | Any misc. TextInput props (autoFocus, placeholder, returnKeyType, etc.) |
 | maxHeight | Max height of the tag input on screen (will scroll if max height reached) |
 | onHeightChange | Callback that gets passed the new component height when it changes |
+| scrollViewProps | Any ScrollView props (horizontal, showsHorizontalScrollIndicator, etc.) |

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ type OptionalProps = {
   /**
    * Any ScrollView props (horizontal, showsHorizontalScrollIndicator, etc.)
   */
-  scrollViewProps: $PropertyType<ScrollView, 'props'>,
+  scrollViewProps?: Object,
 };
 type Props<T> = RequiredProps<T> & OptionalProps;
 type State = {
@@ -115,6 +115,7 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
     inputProps: PropTypes.shape(TextInput.propTypes),
     maxHeight: PropTypes.number,
     onHeightChange: PropTypes.func,
+    // $FlowFixMe: identify EdgeInsetsPropType, PointPropType as React PropType
     scrollViewProps: PropTypes.shape(ScrollView.propTypes),
   };
   props: Props<T>;

--- a/index.js
+++ b/index.js
@@ -86,6 +86,10 @@ type OptionalProps = {
    * Callback that gets passed the new component height when it changes
    */
   onHeightChange?: (height: number) => void,
+  /**
+   * Any ScrollView props (horizontal, showsHorizontalScrollIndicator, etc.)
+  */
+  scrollViewProps: $PropertyType<ScrollView, 'props'>,
 };
 type Props<T> = RequiredProps<T> & OptionalProps;
 type State = {
@@ -111,6 +115,7 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
     inputProps: PropTypes.shape(TextInput.propTypes),
     maxHeight: PropTypes.number,
     onHeightChange: PropTypes.func,
+    scrollViewProps: PropTypes.shape(ScrollView.propTypes),
   };
   props: Props<T>;
   state: State;
@@ -207,6 +212,7 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
     const tags = [...this.props.value];
     tags.pop();
     this.props.onChange(tags);
+    this.scrollToRight();
     this.focus();
   }
 
@@ -232,6 +238,17 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
       "this.scrollView ref should exist before scrollToBottom called",
     );
     scrollView.scrollTo({ y, animated: true });
+  }
+
+  scrollToRight = () => {
+    const scrollView = this.scrollView;
+    invariant(
+      scrollView,
+      "this.scrollView ref should exist before scrollToEnd called",
+    );
+    setTimeout(() => {
+      scrollView.scrollToEnd({ animated: true });
+    }, 0);
   }
 
   render() {
@@ -263,6 +280,7 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
             onContentSizeChange={this.onScrollViewContentSizeChange}
             onLayout={this.onScrollViewLayout}
             keyboardShouldPersistTaps="handled"
+            {...this.props.scrollViewProps}
           >
             <View style={styles.tagInputContainer}>
               {tags}

--- a/index.js
+++ b/index.js
@@ -123,7 +123,6 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
   spaceLeft = 0;
   // scroll to bottom
   contentHeight = 0;
-  scrollViewHeight = 0;
   // refs
   tagInput: ?TextInput = null;
   scrollView: ?ScrollView = null;
@@ -212,7 +211,7 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
     const tags = [...this.props.value];
     tags.pop();
     this.props.onChange(tags);
-    this.scrollToRight();
+    this.scrollToEnd();
     this.focus();
   }
 
@@ -227,20 +226,7 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
     this.props.onChange(tags);
   }
 
-  scrollToBottom = () => {
-    const y = this.contentHeight - this.scrollViewHeight;
-    if (y <= 0) {
-      return;
-    }
-    const scrollView = this.scrollView;
-    invariant(
-      scrollView,
-      "this.scrollView ref should exist before scrollToBottom called",
-    );
-    scrollView.scrollTo({ y, animated: true });
-  }
-
-  scrollToRight = () => {
+  scrollToEnd = () => {
     const scrollView = this.scrollView;
     invariant(
       scrollView,
@@ -278,7 +264,6 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
             ref={this.scrollViewRef}
             style={styles.tagInputContainerScroll}
             onContentSizeChange={this.onScrollViewContentSizeChange}
-            onLayout={this.onScrollViewLayout}
             keyboardShouldPersistTaps="handled"
             {...this.props.scrollViewProps}
           >
@@ -333,18 +318,12 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
     if (nextWrapperHeight !== this.state.wrapperHeight) {
       this.setState(
         { wrapperHeight: nextWrapperHeight },
-        this.contentHeight < h ? this.scrollToBottom : undefined,
+        this.contentHeight < h ? this.scrollToEnd : undefined,
       );
     } else if (this.contentHeight < h) {
-      this.scrollToBottom();
+      this.scrollToEnd();
     }
     this.contentHeight = h;
-  }
-
-  onScrollViewLayout = (
-    event: { nativeEvent: { layout: { height: number } } },
-  ) => {
-    this.scrollViewHeight = event.nativeEvent.layout.height;
   }
 
   onLayoutLastTag = (endPosOfTag: number) => {

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ import invariant from 'invariant';
 
 const windowWidth = Dimensions.get('window').width;
 
+type KeyboardShouldPersistTapsProps =
+  "always" | "never" | "handled" | false | true;
 type RequiredProps<T> = {
   /**
    * An array of tags, which can be any type, as long as labelExtractor below
@@ -89,7 +91,7 @@ type OptionalProps = {
   /**
    * Any ScrollView props (horizontal, showsHorizontalScrollIndicator, etc.)
   */
-  scrollViewProps?: Object,
+  scrollViewProps?: $PropertyType<ScrollView, 'props'>,
 };
 type Props<T> = RequiredProps<T> & OptionalProps;
 type State = {
@@ -265,7 +267,9 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
             ref={this.scrollViewRef}
             style={styles.tagInputContainerScroll}
             onContentSizeChange={this.onScrollViewContentSizeChange}
-            keyboardShouldPersistTaps="handled"
+            keyboardShouldPersistTaps={
+              ("handled": KeyboardShouldPersistTapsProps)
+            }
             {...this.props.scrollViewProps}
           >
             <View style={styles.tagInputContainer}>


### PR DESCRIPTION
Considerations: 
It's good when scrolling horizontally to have the similar behaviour as when scrolling vertically

1. Deleting a previous tag (removeIndex) shouldn't trigger scrolling to end (to maintain visibility of adjacent tags); 
2. Deleting the last tag (‘Backspace’ on iOS, maybe on Android in the future) should trigger scrolling to end, especially if the textInput has been scrolled out of sight; 
3. Adding a new tag should trigger scrolling to end (to see the newly added tag), especially when the input area is previously being scrolled out of sight. 

The vertical scroll behaviours has been handled by onContentSizeChange, I guess it makes sense especially when some existing tags and textInput are in the same line, and textInput contentSize has grown outside the right edge and been flex wrapped to the next line.
However it seems to still have some minor issues like not on Android but iOS sometimes it’s overscrolling down while some other times it doesn’t start scrolling even the last line is partly covered. 

While the horizontal scroll case is a bit simpler, when textInput contentSize has exceeded, even Instagram is keeping the position of existing tags instead of doing endless scroll to the end, so the user will be always safe to see those tags, and frankly the searching string entered usually doesn’t need to be so long. Also scrollView.scrollToEnd() has been supported since RN 0.42. So it’s simpler to check and use scrollToEnd for the above 3 events instead of checking in onContentSizeChange. 

P.S. 
As mentioned by @Ashoat in #42  and shown in text lifting PR #43 , it’s better for the parent to manage and add new tag (like in onChangeText, autocompletion or multi-selection components). So after #43 has been merged, I guess in order to handle event 3, the user could still find the scrollToRight() helpful as a public helper function just like ScrollView did. 

I also eliminated my old refactors in #42 for easier merge of possible incoming text lifting PR. Please fell free to refactor later whenever appropriate. 