### PR TITLE
added blur and scrollToTop methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,6 +223,11 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
     this.tagInput.focus();
   }
 
+  blur = () => {
+    invariant(this.tagInput, "should be set");
+    this.tagInput.blur();
+  }
+
   removeIndex = (index: number) => {
     const tags = [...this.props.value];
     tags.splice(index, 1);
@@ -239,6 +244,18 @@ class TagInput<T> extends React.PureComponent<Props<T>, State> {
       scrollView.scrollToEnd({ animated: true });
     }, 0);
   }
+
+  scrollToTop = () => {
+    const scrollView = this.scrollView;
+    invariant(
+      scrollView,
+      "this.scrollView ref should exist before scrollToEnd called",
+    );
+    setTimeout(() => {
+      scrollView.scrollTo({x: 0, y: 0, animated: true });
+    }, 0);
+  }
+
 
   render() {
     const tags = this.props.value.map((tag, index) => (


### PR DESCRIPTION
I needed to add ScrollToTop  in order to resolve the bug shown here: https://wetransfer.com/downloads/b1a574a6cba5556eb3d509e0fc9d273420171211114913/f5de232efb03cee87afcc701ce39a8d920171211114913/8fcd45

As you can see the caret was on top of the scrollview and therefore hidden since the scrollview was not on its top.

Also, autoFocus was not good for me because when using React Navigation, this causes a frame drop. So I had to delay the focus when entering the screen, but also make sure to blur the textInput before leaving the screen. I tried to get textInput ref in the begining, but this was causing another bug because since both my component and TagInput were trying to retrieve the same ref, only one component can retrieve the ref, causing TagInput to have a null ref for TextInput. So my only solution was to implement scrollToTop.